### PR TITLE
gitignore the files built when running cmake .

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+CCBS
+cmake_install.cmake
+CMakeCache.txt
+CMakeFiles/*
+Makefile


### PR DESCRIPTION
Just adding a gitignore so we don't accidentally push binaries to github